### PR TITLE
fix : broken link error for gitlab pages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -101,10 +101,6 @@ const config = {
             to: '/blog',
           },
           {
-            label: 'Project',
-            to: '/project',
-          },
-          {
             label: 'GitHub',
             href: 'https://github.com/facebook/docusaurus',
           },


### PR DESCRIPTION
```
  [cause]: Error: Docusaurus found broken links!
  
  Please check the pages of your site in the list below, and make sure you don't reference any path that does not exist.
  Note: it's possible to ignore broken links with the 'onBrokenLinks' Docusaurus configuration, and let the build pass.
  
  It looks like some of the broken links we found appear in many pages of your site.
  Maybe those broken links appear on all pages through your site layout?
  We recommend that you check your theme configuration for such links (particularly, theme navbar and footer).
  Frequent broken links are linking to:
  - /project
  ```